### PR TITLE
converted main.workflow to Actions V2 yml files

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,8 +1,0 @@
-workflow "Trigger: Push" {
-  on = "push"
-  resolves = ["Shellcheck"]
-}
-
-action "Shellcheck" {
-  uses = "ludeeus/action-shellcheck@master"
-}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,10 @@
+on: push
+name: 'Trigger: Push'
+jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Shellcheck
+      uses: ludeeus/action-shellcheck@master


### PR DESCRIPTION
According to https://help.github.com/en/articles/migrating-github-actions-from-hcl-syntax-to-yaml-syntax, Support for the HCL syntax in GitHub Actions will be deprecated on September 30, 2019.