### PR TITLE
apply to all Bash, Ksh, Zsh & POSIX Shell files

### DIFF
--- a/runaction.sh
+++ b/runaction.sh
@@ -1,6 +1,43 @@
-#!/bin/bash
+#!/bin/sh
 
-cd "$GITHUB_WORKSPACE" || exit 1
-find . -name \*.sh -exec shellcheck {} +
-find . -name \*.bashrc -exec shellcheck {} +
-find . -name \*.bash_profile -exec shellcheck {} +
+cd "$GITHUB_WORKSPACE" || exit
+
+find . '(' -name   '*.bash' \
+        -o -path '*/.bash*'     -o -path '*/bash*' \
+        \
+        -o -name   '*.ksh' \
+        -o -name   'ksh*'  \
+        -o -path '*/.ksh*'      -o -path '*/ksh*'  \
+        \
+        -o -name   '*.zsh' \
+        -o -name   '.zlogin*'   -o -name   'zlogin*'   \
+        -o -name   '.zlogout*'  -o -name   'zlogout*'  \
+        -o -name   '.zprofile*' -o -name   'zprofile*' \
+        -o -path '*/.zsh*'      -o -path '*/zsh*'      \
+        \
+        -o -name   '*.sh' \
+        -o -path '*/.profile*'  -o -path '*/profile*' \
+        -o -path '*/.shlib*'    -o -path '*/shlib*'   \
+       ')' -exec shellcheck {} + || exit
+
+# shellcheck disable=SC2016
+find . -type f ! -name '*.*' -perm /111 -exec sh -c '
+        for f
+        do
+            head -n1 "$f" | grep -Eqs "^#! */[^ ]*/[abkz]*sh" || continue
+            shellcheck "$f" || err=$?
+        done
+        exit $err
+        ' _ {} + || exit
+
+if  find . -path '*bin/*/*' -type f -perm /111 -print |
+    grep .
+then
+    echo >&2 "WARNING: subdirectories of bin directories are not usable via PATH"
+fi
+
+if  find . -path '*bin/*' -name '*.*' -type f -perm /111 -perm /444 -print |
+    grep .
+then
+    echo >&2 "WARNING: programs in PATH should not have a filename suffix"
+fi

--- a/runaction.sh
+++ b/runaction.sh
@@ -8,6 +8,7 @@ find . '(' -name   '*.bash' \
         -o -name   '*.ksh' \
         -o -name   'ksh*'  \
         -o -path '*/.ksh*'      -o -path '*/ksh*'  \
+        -o -name   'suid_profile' \
         \
         -o -name   '*.zsh' \
         -o -name   '.zlogin*'   -o -name   'zlogin*'   \


### PR DESCRIPTION
Does not need bash to run; standard posix sh suffices.

Apply shellcheck to:

* files with shbang lines that indicate a shell (sh, bash, ash, bsh, ksh, zsh)

* typical home directory shell startup files:
  for posix sh & all shells: .profile
  for bash: .bashrc, .bash_aliases, .bash_completion, .bash_login, .bash_logout, .bash_profile
  for ksh: .profile
  for zsh: .zprofile, .zlogin, .zlogout, .zshenv, .zshrc

* typical system-wide shell startup files:
  for posix sh & all shells: /etc/profile
  for bash: /etc/bashrc, /etc/bash_profile
  for ksh: /etc/suid_profile
  for zsh: /etc/zprofile, /etc/zlogin, /etc/zlogout, /etc/zshenv, /etc/zshrc

* files with suffixes: .bash, .zsh, .ksh, & .sh

Warn about bad practices for naming scripts.