### PR TITLE
Added mvnw to excludes

### DIFF
--- a/runaction.sh
+++ b/runaction.sh
@@ -11,6 +11,7 @@ statuscode=0
 
 excludes+=( ! -path *./.git/* )
 excludes+=( ! -path *.go )
+excludes+=( ! -path */mvnw )
 
 for path in ${INPUT_IGNORE}; do
     echo "::debug:: Adding '${path}' to excludes"


### PR DESCRIPTION
Added maven-wrapper (https://github.com/takari/maven-wrapper)

I couldn't see a way to exclude a single file, i.e.: /some/where/in/my/gitrepo/mvnw - so have added it to the excludes

If this isn't excluded for java projects which use mvnw (which is quite a lot), lots of issues are raised, but since mvnw is a generated file not under the control of the source repo, its not feasible to fix them.