### PR TITLE
Add the ability to check all scripts in one shellcheck command

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,19 @@ example:
       with:
         severity: error
 ```
+
+## Run shellcheck with all paths in a single invocation
+
+If you run into SC1090/SC1091 errors you may need to tell shellcheck to check
+all files at once:
+
+```yaml
+    ...
+    - name: Run ShellCheck
+    uses: ludeeus/action-shellcheck@master
+    with:
+      check_together: 'yes'
+```
+
+This can turn into a problem if you have enough script files to overwhelm the
+maximum argv length on your system.

--- a/action.yaml
+++ b/action.yaml
@@ -10,6 +10,10 @@ inputs:
     description: 'Minimum severity of errors to consider. Options: [error, warning, info, style]'
     required: false
     default: ''
+  check_together:
+    description: 'Run shellcheck on _all_ files at once, instead of one at a time'
+    required: false
+    default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/runaction.sh
+++ b/runaction.sh
@@ -68,9 +68,15 @@ fi
 
 [[ -n "${INPUT_SEVERITY}" ]] && options+=(-S "${INPUT_SEVERITY}")
 
-for file in "${filepaths[@]}"; do
-    echo "::debug:: Checking $file"
-    shellcheck "${options[@]}" "$file" || statuscode=$?
-done
+if [[ -n "$INPUT_CHECK_TOGETHER" ]]; then
+    echo "::debug:: shellcheck ${options[*]} ${filepaths[*]}"
+    shellcheck "${options[@]}" "${filepaths[@]}" || statuscode=$?
+else
+    echo "::debug:: Shellcheck options: ${options[*]}"
+    for file in "${filepaths[@]}"; do
+        echo "::debug:: Checking $file"
+        shellcheck "${options[@]}" "$file" || statuscode=$?
+    done
+fi
 
 exit "$statuscode"


### PR DESCRIPTION
This is the most straightforward way to allow sourcing scripts, as shellcheck
[SC1090] only allows `source` files that are in the same invocation, I believe
unless `-x` is also specified.

[SC1090]: https://github.com/koalaman/shellcheck/wiki/SC1090