### PR TITLE
Add filetype to find command

### DIFF
--- a/runaction.sh
+++ b/runaction.sh
@@ -19,7 +19,7 @@ for path in ${INPUT_IGNORE}; do
     excludes+=(! -path "*/${path}/*" )
 done
 
-readarray -d '' filepaths < <(find . "${excludes[@]}" \
+readarray -d '' filepaths < <(find . -type f "${excludes[@]}" \
     '(' \
     \
     -name '*.bash' \


### PR DESCRIPTION
This fixes an error when a directory contains "bash" in the name. This
would lead to a shellcheck on a directory and crash.

Fixes #18 