### PR TITLE
Enable shellcheck for shebang with /bin/env

### DIFF
--- a/runaction
+++ b/runaction
@@ -53,7 +53,7 @@ readarray -d '' filepaths < <(find . -type f "${excludes[@]}" \
 
 readarray -d '' tmp < <(find . "${excludes[@]}" -type f ! -name '*.*' -perm /111  -print0)
 for file in "${tmp[@]}"; do
-    head -n1 "$file" | grep -Eqs "^#! */[^ ]*/[abkz]*sh" || continue
+    head -n1 "$file" | grep -Eqs "^#! */[^ ]*/(env *)?[abkz]*sh" || continue
     filepaths+=("$file")
 done
 


### PR DESCRIPTION
The grep in the `runaction` was incomplete and doesn't work for my shebag that uses `env`, i.e. I had
```sh
#!/usr/bin/env sh
...
```

This simple PR adds an optional capture group for shebang with pattern `/../../env SHELL`.