### PR TITLE
Fixes issues with globbing files with partial match

### DIFF
--- a/runaction
+++ b/runaction
@@ -27,19 +27,32 @@ readarray -d '' filepaths < <(find . -type f "${excludes[@]}" \
     \
     -name '*.bash' \
     -o -path '*/.bash*' \
+    -o -name '.bashrc' \
+    -o -name 'bashrc' \
+    -o -name '.bash_aliases' \
+    -o -name '.bash_completion' \
+    -o -name '.bash_login' \
+    -o -name '.bash_logout' \
+    -o -name '.bash_profile' \
+    -o -name 'bash_profile' \
     -o -name '*.ksh' \
     -o -path '*/.ksh*' \
     -o -name 'suid_profile' \
     -o -name '*.zsh' \
-    -o -name '.zlogin*' \
-    -o -name 'zlogin*' \
-    -o -name '.zlogout*' \
-    -o -name 'zlogout*' \
-    -o -name '.zprofile*' \
-    -o -name 'zprofile*' \
+    -o -name '.zlogin' \
+    -o -name 'zlogin' \
+    -o -name '.zlogout' \
+    -o -name 'zlogout' \
+    -o -name '.zprofile' \
+    -o -name 'zprofile' \
+    -o -name '.zsenv' \
+    -o -name 'zsenv' \
+    -o -name '.zshrc' \
+    -o -name 'zshrc' \
     -o -path '*/.zsh*' \
     -o -name '*.sh' \
-    -o -path '*/.profile*' \
+    -o -path '*/.profile' \
+    -o -path '*/profile' \
     -o -path '*/.shlib*' \
        ')'\
     \

--- a/runaction
+++ b/runaction
@@ -26,7 +26,6 @@ readarray -d '' filepaths < <(find . -type f "${excludes[@]}" \
     '(' \
     \
     -name '*.bash' \
-    -o -path '*/.bash*' \
     -o -name '.bashrc' \
     -o -name 'bashrc' \
     -o -name '.bash_aliases' \
@@ -36,7 +35,6 @@ readarray -d '' filepaths < <(find . -type f "${excludes[@]}" \
     -o -name '.bash_profile' \
     -o -name 'bash_profile' \
     -o -name '*.ksh' \
-    -o -path '*/.ksh*' \
     -o -name 'suid_profile' \
     -o -name '*.zsh' \
     -o -name '.zlogin' \
@@ -49,11 +47,10 @@ readarray -d '' filepaths < <(find . -type f "${excludes[@]}" \
     -o -name 'zsenv' \
     -o -name '.zshrc' \
     -o -name 'zshrc' \
-    -o -path '*/.zsh*' \
     -o -name '*.sh' \
     -o -path '*/.profile' \
     -o -path '*/profile' \
-    -o -path '*/.shlib*' \
+    -o -name '*.shlib' \
        ')'\
     \
     -print0)

--- a/runaction
+++ b/runaction
@@ -27,11 +27,8 @@ readarray -d '' filepaths < <(find . -type f "${excludes[@]}" \
     \
     -name '*.bash' \
     -o -path '*/.bash*' \
-    -o -path '*/bash*' \
     -o -name '*.ksh' \
-    -o -name 'ksh*' \
     -o -path '*/.ksh*' \
-    -o -path '*/ksh*' \
     -o -name 'suid_profile' \
     -o -name '*.zsh' \
     -o -name '.zlogin*' \
@@ -41,11 +38,9 @@ readarray -d '' filepaths < <(find . -type f "${excludes[@]}" \
     -o -name '.zprofile*' \
     -o -name 'zprofile*' \
     -o -path '*/.zsh*' \
-    -o -path '*/zsh*' \
     -o -name '*.sh' \
     -o -path '*/.profile*' \
     -o -path '*/.shlib*' \
-    -o -path '*/shlib*' \
        ')'\
     \
     -print0)

--- a/runaction
+++ b/runaction
@@ -10,6 +10,7 @@ declare -a excludes
 declare -a tmp
 
 statuscode=0
+shebangregex="^#! */[^ ]*/(env *)?[abkz]*sh"
 
 excludes+=( ! -path *./.git/* )
 excludes+=( ! -path *.go )
@@ -48,11 +49,15 @@ readarray -d '' filepaths < <(find . -type f "${excludes[@]}" \
        ')'\
     \
     -print0)
-
+# remove files from filelist without shebang
+for file in "${!filepaths[@]}"; do
+    head -n1 "${filepaths[file]}" | grep -Eqs "$shebangregex" && continue
+    unset 'filepaths[file]'
+done
 
 readarray -d '' tmp < <(find . "${excludes[@]}" -type f ! -name '*.*' -perm /111  -print0)
 for file in "${tmp[@]}"; do
-    head -n1 "$file" | grep -Eqs "^#! */[^ ]*/(env *)?[abkz]*sh" || continue
+    head -n1 "$file" | grep -Eqs "$shebangregex" || continue
     filepaths+=("$file")
 done
 

--- a/runaction
+++ b/runaction
@@ -54,11 +54,6 @@ readarray -d '' filepaths < <(find . -type f "${excludes[@]}" \
        ')'\
     \
     -print0)
-# remove files from filelist without shebang
-for file in "${!filepaths[@]}"; do
-    head -n1 "${filepaths[file]}" | grep -Eqs "$shebangregex" && continue
-    unset 'filepaths[file]'
-done
 
 readarray -d '' tmp < <(find . "${excludes[@]}" -type f ! -name '*.*' -perm /111  -print0)
 for file in "${tmp[@]}"; do

--- a/testfiles/bashfile.c
+++ b/testfiles/bashfile.c
@@ -1,0 +1,6 @@
+/* C code test file
+ * file that should not be matched for shellcheck runs
+ */
+int main(void) {
+    return 0;
+}


### PR DESCRIPTION
List of files is checked for shebang in order to prevent matching files that start with `[bakz]sh` but are not shellscripts like e.g. `bashfile.c`.