### PR TITLE
Update action checkout to the new default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ jobs:
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@main
+    - uses: actions/checkout@v2
     - name: Run ShellCheck
       uses: ludeeus/action-shellcheck@master
 ```

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ jobs:
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@main
     - name: Run ShellCheck
       uses: ludeeus/action-shellcheck@master
 ```


### PR DESCRIPTION
Hello,

I recently saw that there is a new default branch on the checkout action and that your documentation is pointing to the wrong one. (as you can see in the picture here)
![image](https://user-images.githubusercontent.com/1763930/88524573-cfe63b80-cff9-11ea-9cbd-b2edad08f85f.png)

I propose an update to the new default one.

Another proposition could be to define `actions/checkout@v2` as they propose in their "Usage" documentation https://github.com/actions/checkout#usage

I let you decide what you prefer and I'll update the PR if needed.

Thanks