### PR TITLE
Updates README to include ShellCheck flag/options usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,14 @@ jobs:
       uses: ludeeus/action-shellcheck@master
 ```
 
-## Globally disable checks
+## ShellCheck options
 
-To disable specific checks add it to a `SHELLCHECK_OPTS` env key in the job definition.
+You can pass any supported ShellCheck option or flag with the `SHELLCHECK_OPTS` env key in the job definition.
+
+Some examples include:
+
+* To disable specific checks (eg: `-e SC2059 -e SC2034 -e SC1090`)
+* To test against different shells (eg: `-s dash` or `-s ksh`)
 
 example:
 


### PR DESCRIPTION
Per my confusion on issue #34, it would be nice to clarify that the `SHELLCHECK_OPTS` env key can be used for multiple flags or options instead of being about `specific checks`.

This diff makes this section in the README more generic and providing additional examples.