### PR TITLE
Add Display shellcheck version step

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -65,6 +65,11 @@ runs:
         mv "${{ github.action_path }}/shellcheck-${scversion}/shellcheck" \
           "${{ github.action_path }}/shellcheck"
 
+    - name: Display shellcheck version
+      shell: bash
+      run: |
+        "${{ github.action_path }}/shellcheck" --version
+
     - name: Set options
       shell: bash
       id: options


### PR DESCRIPTION
Currently it is hidden.
https://github.com/bpkg/bpkg/pull/128/checks?check_run_id=1714506179