### PR TITLE
fix: multiline problem matcher

### DIFF
--- a/.github/problem-matcher.json
+++ b/.github/problem-matcher.json
@@ -14,9 +14,10 @@
           {
               "regexp": "(SC\\d+):\\s(.+)$",
               "code": 1,
-              "message": 2
+              "message": 2,
+              "loop": true
           }
-      ]
+        ]
       }
     ]
   }


### PR DESCRIPTION
From the [docs](https://github.com/actions/toolkit/blob/main/docs/problem-matchers.md#multiline-matching):

> loop: whether to loop until a match is not found, only valid on the last pattern of a multipattern matcher