### PR TITLE
Updated matchers to account for "./" file prefixes

### DIFF
--- a/.github/problem-matcher-gcc.json
+++ b/.github/problem-matcher-gcc.json
@@ -4,7 +4,7 @@
       "owner": "shellcheck-gcc",
       "pattern": [
         {
-          "regexp": "^(.+):(\\d+):(\\d+):\\s(note|warning|error):\\s(.*)\\s\\[(SC\\d+)\\]$",
+          "regexp": "^\\.\\/(.+):(\\d+):(\\d+):\\s(note|warning|error):\\s(.*)\\s\\[(SC\\d+)\\]$",
           "file": 1,
           "line": 2,
           "column": 3,

--- a/.github/problem-matcher-tty.json
+++ b/.github/problem-matcher-tty.json
@@ -4,7 +4,7 @@
         "owner": "shellcheck-tty",
         "pattern": [
           {
-              "regexp": "^In\\s(.+)\\sline\\s(\\d+):$",
+              "regexp": "^In\\s\\.\\/(.+)\\sline\\s(\\d+):$",
               "file": 1,
               "line": 2
           },


### PR DESCRIPTION
The files are shown with a `./` prefix so they fail to string match the files on the disk. This updates the regex to account for this prefix.

Sample output:

```
##[debug]Checking ./catpants.sh
##[debug]Checking ./deploy-all-the-things.sh
Error: ./deploy-all-the-things.sh:116:6: error: Couldn't parse this test expression. Fix to allow more checks. [SC1073]
Error: ./deploy-all-the-things.sh:127:30: error: Expected test to end here (don't wrap commands in []/[[]]). Fix any mentioned problems and try again. [SC1072]
##[debug]Checking ./foo-bar
```

Since `./deploy-all-the-things.sh` does not match `deploy-all-the-things.sh`, it would not annotate the file.