### PR TITLE
Allow specifying ShellCheck version

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,3 +147,15 @@ Only `tty` and `gcc` produce file annotations via problem matcher, default is `g
      with:
        format: tty
 ```
+
+## Run a specific version of Shellcheck
+
+If running the latest stable version of Shellcheck is not to your liking, you can specify a concrete version of Shellcheck to be used. When specifying a custom version, please use any of the released versions listed in the [Shellcheck repository](https://github.com/koalaman/shellcheck/tags).
+
+```yaml
+   ...
+   - name: Run ShellCheck
+     uses: ludeeus/action-shellcheck@master
+     with:
+       shellcheck_version: v0.7.0
+```

--- a/action.yaml
+++ b/action.yaml
@@ -30,6 +30,10 @@ inputs:
     description: "Output format (checkstyle, diff, gcc, json, json1, quiet, tty)"
     required: false
     default: "gcc"
+  shellcheck_version:
+    description: "Specify a concrete version of ShellCheck to use"
+    required: false
+    default: "stable"
 outputs:
   files:
     description: A list of files with issues
@@ -60,7 +64,7 @@ runs:
           osvariant="linux"
         fi
 
-        scversion="stable"
+        scversion="${{ inputs.shellcheck_version }}"
         baseurl="https://github.com/koalaman/shellcheck/releases/download"
 
         curl -Lso "${{ github.action_path }}/sc.tar.xz" \


### PR DESCRIPTION
I think this PR fixes #43 but honestly, I’m not sure how to test this on my own…