### PR TITLE
Split ignore into ignore_paths and ignore_names

### DIFF
--- a/.github/workflows/additional_files.yml
+++ b/.github/workflows/additional_files.yml
@@ -23,7 +23,7 @@ jobs:
       id: check
       with:
         additional_files: run finish discovery
-        ignore: ignore
+        ignore_paths: ignore
         scandir: testfiles
 
     - name: Verify check

--- a/.github/workflows/ignore_names.yml
+++ b/.github/workflows/ignore_names.yml
@@ -22,6 +22,7 @@ jobs:
       uses: ./
       id: check
       with:
+        ignore_paths: ignore
         ignore_names: ignore_single_file.sh
 
     - name: Verify check

--- a/.github/workflows/ignore_names.yml
+++ b/.github/workflows/ignore_names.yml
@@ -1,4 +1,4 @@
-name: 'base'
+name: 'ignore_names'
 
 on: 
   push:
@@ -6,8 +6,8 @@ on:
   pull_request:
 
 jobs:
-  base:
-    name: base
+  ignore_names:
+    name: ignore_names
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -22,12 +22,12 @@ jobs:
       uses: ./
       id: check
       with:
-        ignore: ignore
+        ignore_names: ignore_single_file.sh
 
     - name: Verify check
       run: | 
         expect="testfiles/test.bash"
-        notexpect="testfiles/ignore/ignore.bash"
+        notexpect="testfiles/ignore_single_file.sh"
 
         if [[ ! "${{ steps.check.outputs.files }}" =~ $expect ]];then
           echo "::error:: Expected file $expect not found in ${{ steps.check.outputs.files }}"
@@ -36,3 +36,5 @@ jobs:
           echo "::error:: Expected file $notexpect found in ${{ steps.check.outputs.files }}"
           exit 1
         fi 
+
+

--- a/.github/workflows/ignore_paths.yml
+++ b/.github/workflows/ignore_paths.yml
@@ -35,7 +35,4 @@ jobs:
         elif [[ "${{ steps.check.outputs.files }}" =~ $notexpect ]];then
           echo "::error:: Expected file $notexpect found in ${{ steps.check.outputs.files }}"
           exit 1
-        fi 
-
-
-ignore_single_file.sh
+        fi

--- a/.github/workflows/ignore_paths.yml
+++ b/.github/workflows/ignore_paths.yml
@@ -1,4 +1,4 @@
-name: 'check_together'
+name: 'ignore_paths'
 
 on: 
   push:
@@ -6,8 +6,8 @@ on:
   pull_request:
 
 jobs:
-  check_together:
-    name: check_together
+  ignore_paths:
+    name: ignore_paths
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -23,7 +23,6 @@ jobs:
       id: check
       with:
         ignore_paths: ignore
-        check_together: true
 
     - name: Verify check
       run: | 
@@ -37,3 +36,6 @@ jobs:
           echo "::error:: Expected file $notexpect found in ${{ steps.check.outputs.files }}"
           exit 1
         fi 
+
+
+ignore_single_file.sh

--- a/.github/workflows/scandir.yml
+++ b/.github/workflows/scandir.yml
@@ -42,7 +42,7 @@ jobs:
       id: two
       with:
         scandir: './testfiles/scandir'
-        ignore: ignore
+        ignore_paths: ignore
 
     - name: Verify check
       run: | 

--- a/README.md
+++ b/README.md
@@ -41,15 +41,16 @@ example:
         SHELLCHECK_OPTS: -e SC2059 -e SC2034 -e SC1090
 ```
 
-## Ignore paths
+## Ignore paths and names
 
-You can use the `ignore` input to disable specific directories.
+You can use the `ignore_paths` and `ignore_names` input to disable specific directories and files.
 
 ```text
 sample structure:
 sample/directory/with/files/ignoreme/test.sh
 sample/directory/with/files/ignoremetoo/test.sh
 sample/directory/with/files/test.sh
+sample/directory/with/files/ignorable.sh
 ```
 
 example:
@@ -59,10 +60,11 @@ example:
     - name: Run ShellCheck
       uses: ludeeus/action-shellcheck@master
       with:
-        ignore: ignoreme ignoremetoo
+        ignore_paths: ignoreme ignoremetoo
+        ignore_names: ignorable.sh
 ```
 
-This will skip `sample/directory/with/files/ignoreme/test.sh` and `sample/directory/with/files/ignoremetoo/test.sh`
+This will skip `sample/directory/with/files/ignoreme/test.sh`, `sample/directory/with/files/ignoremetoo/test.sh` and `sample/directory/with/files/ignorable.sh`.
 
 ## Minimum severity of errors to consider (error, warning, info, style)
 

--- a/action.yaml
+++ b/action.yaml
@@ -10,6 +10,14 @@ inputs:
     description: "Paths to ignore when running ShellCheck"
     required: false
     default: ""
+  ignore_paths:
+    description: "Paths to ignore when running ShellCheck"
+    required: false
+    default: ""
+  ignore_names:
+    description: "Names to ignore when running ShellCheck"
+    required: false
+    default: ""
   severity:
     description: "Minimum severity of errors to consider. Options: [error, warning, info, style]"
     required: false
@@ -98,10 +106,24 @@ runs:
         excludes+=("! -path \"*./.git/*\"")
         excludes+=("! -path \"*.go\"")
         excludes+=("! -path \"*/mvnw\"")
-        for path in ${{ inputs.ignore }}; do
-          echo "::debug:: Adding "$path" to excludes"
-          excludes+=("! -path \"*./$path/*\"")
-          excludes+=("! -path \"*/$path/*\"")
+        if [[ -n "${{ inputs.ignore }}" ]]; then
+          echo "::warning::ignore is deprecated. Please use ignore_paths instead"
+          for path in ${{ inputs.ignore }}; do
+            echo "::debug:: Adding "$path" to excludes"
+            excludes+=("! -path \"*./$path/*\"")
+            excludes+=("! -path \"*/$path/*\"")
+          done
+        else
+          for path in ${{ inputs.ignore_paths }}; do
+            echo "::debug:: Adding "$path" to excludes"
+            excludes+=("! -path \"*./$path/*\"")
+            excludes+=("! -path \"*/$path/*\"")
+          done
+        fi
+
+        for name in ${{ inputs.ignore_names }}; do
+          echo "::debug:: Adding "$name" to excludes"
+          excludes+=("! -name $name")
         done
         echo "::set-output name=excludes::${excludes[@]}"
 

--- a/testfiles/ignore_single_file.sh
+++ b/testfiles/ignore_single_file.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/sh
+
+test="test"
+echo "$test"


### PR DESCRIPTION
Closes #41

- Deprecates the usage of the `ignore` input (`ignore_paths` should be used instead).
- Adds new `ignore_names` input to ignore names