### PR TITLE
Fix warnings reported by shellcheck

### DIFF
--- a/.github/workflows/scandir.yml
+++ b/.github/workflows/scandir.yml
@@ -1,6 +1,6 @@
 name: 'scandir'
 
-on: 
+on:
   push:
     branches: ["master"]
   pull_request:
@@ -25,8 +25,8 @@ jobs:
         scandir: testfiles/scandir
 
     - name: Verify check
-      run: | 
-        expect="testfiles/scandir/test.bash"
+      run: |
+        expect="testfiles/scandir/run[[:space:]]me.bash"
         notexpect="testfiles/test.bash"
 
         if [[ ! "${{ steps.one.outputs.files }}" =~ $expect ]];then
@@ -35,7 +35,7 @@ jobs:
         elif [[ "${{ steps.one.outputs.files }}" =~ $notexpect ]];then
           echo "::error:: Expected file $notexpect found in ${{ steps.one.outputs.files }}"
           exit 1
-        fi 
+        fi
 
     - name: Run ShellCheck
       uses: ./
@@ -45,7 +45,7 @@ jobs:
         ignore_paths: ignore
 
     - name: Verify check
-      run: | 
+      run: |
         expect="testfiles/scandir/test.bash"
         notexpect="testfiles/test.bash"
 
@@ -55,4 +55,4 @@ jobs:
         elif [[ "${{ steps.two.outputs.files }}" =~ $notexpect ]];then
           echo "::error:: Expected file $notexpect found in ${{ steps.two.outputs.files }}"
           exit 1
-        fi 
+        fi

--- a/action.yaml
+++ b/action.yaml
@@ -45,7 +45,7 @@ inputs:
 outputs:
   files:
     description: A list of files with issues
-    value: ${{ steps.filepaths.outputs.filepaths }}
+    value: ${{ steps.check.outputs.filepaths }}
   options:
     description: The options used
     value: ${{ steps.options.outputs.options }}
@@ -109,20 +109,20 @@ runs:
         if [[ -n "${{ inputs.ignore }}" ]]; then
           echo "::warning::ignore is deprecated. Please use ignore_paths instead"
           for path in ${{ inputs.ignore }}; do
-            echo "::debug:: Adding "$path" to excludes"
+            echo "::debug:: Adding '$path' to excludes"
             excludes+=("! -path \"*./$path/*\"")
             excludes+=("! -path \"*/$path/*\"")
           done
         else
           for path in ${{ inputs.ignore_paths }}; do
-            echo "::debug:: Adding "$path" to excludes"
+            echo "::debug:: Adding '$path' to excludes"
             excludes+=("! -path \"*./$path/*\"")
             excludes+=("! -path \"*/$path/*\"")
           done
         fi
 
         for name in ${{ inputs.ignore_names }}; do
-          echo "::debug:: Adding "$name" to excludes"
+          echo "::debug:: Adding '$name' to excludes"
           excludes+=("! -name $name")
         done
         echo "::set-output name=excludes::${excludes[@]}"
@@ -133,20 +133,24 @@ runs:
       run: |
         declare -a files
         for file in ${{ inputs.additional_files }}; do
-          echo "::debug:: Adding "$file" to excludes"
+          echo "::debug:: Adding '$file' to excludes"
           files+=("-o -name \"*$file\"")
         done
         echo "::set-output name=files::${files[@]}"
 
-    - name: Gather base file paths
+    - name: Run the check
       shell: bash
-      id: filepaths
+      id: check
       run: |
+        statuscode=0
         declare -a filepaths
         shebangregex="^#! */[^ ]*/(env *)?[abk]*sh"
 
-        for path in $(find "${{ inputs.scandir }}" \
-            -type f -type f ${{ steps.exclude.outputs.excludes }} \
+        while IFS= read -r -d '' file; do
+          filepaths+=("$file")
+        done < <(find "${{ inputs.scandir }}" \
+            ${{ steps.exclude.outputs.excludes }} \
+            -type f \
             '(' \
             -name '*.bash' \
             -o -name '.bashrc' \
@@ -175,44 +179,39 @@ runs:
             -o -path '*/profile' \
             -o -name '*.shlib' \
             ${{ steps.additional.outputs.files }} \
-              ')'\
-            -print); do
-          filepaths+=("$path");
-        done
+            ')' \
+            -print0)
 
-        for file in $(find "${{ inputs.scandir }}" ${{ steps.exclude.outputs.excludes }} -type f ! -name '*.*' -perm /111  -print); do
+        while IFS= read -r -d '' file; do
           head -n1 "$file" | grep -Eqs "$shebangregex" || continue
-          filepaths+=("$file");
-        done
-        echo "::set-output name=filepaths::${filepaths[@]}"
-
-    - name: Run the file check
-      id: check
-      shell: bash
-      run: |
-        statuscode=0
+          filepaths+=("$file")
+        done < <(find "${{ inputs.scandir }}" \
+            ${{ steps.exclude.outputs.excludes }} \
+            -type f ! -name '*.*' -perm /111 \
+            -print0)
 
         if [[ -n "${{ inputs.check_together }}" ]]; then
-           "${{ github.action_path }}/shellcheck" \
-           ${{ steps.options.outputs.options }} \
-           ${{ steps.filepaths.outputs.filepaths }} || statuscode=$?
-        else
-          for file in ${{ steps.filepaths.outputs.filepaths }}; do
-            echo "::debug::Checking $file"
-            "${{ github.action_path }}/shellcheck" \
+          "${{ github.action_path }}/shellcheck" \
             ${{ steps.options.outputs.options }} \
-            "$file" || statuscode=$?;
+            "${filepaths[@]}" || statuscode=$?
+        else
+          for file in "${filepaths[@]}"; do
+            echo "::debug::Checking '$file'"
+            "${{ github.action_path }}/shellcheck" \
+              ${{ steps.options.outputs.options }} \
+              "$file" || statuscode=$?
           done
         fi
 
+        echo "::set-output name=filepaths::${filepaths[@]}"
         echo "::set-output name=statuscode::$statuscode"
 
     - name: Print information
       shell: bash
       run: |
-        echo "Files: ${{steps.filepaths.outputs.filepaths}}"
+        echo "Files: ${{ steps.check.outputs.filepaths }}"
         echo "Excluded: ${{ steps.exclude.outputs.excludes }}"
         echo "Options: ${{ steps.options.outputs.options }}"
-        echo "Status code: ${{steps.check.outputs.statuscode}}"
+        echo "Status code: ${{ steps.check.outputs.statuscode }}"
 
         exit ${{steps.check.outputs.statuscode}}

--- a/testfiles/scandir/run me.bash
+++ b/testfiles/scandir/run me.bash
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "I love spaces"


### PR DESCRIPTION
It seems that the `shellcheck` has not been run on the action runner itself. There was a common error with iteration over find results with a simple for-loop. Such loop does not handle correctly file names with spaces. This PR fixes that issue. However, I had to join two steps ("Gather base file paths" and "Run the file check") into one. GitHub does not support passing array variable between steps, and passing gathered files in a simple string will not work for file names with spaces. To prevent mistakes like that in the future, I've added a test file with a whitespace in the name.