### PR TITLE
support running action in containers

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -62,7 +62,7 @@ runs:
         INPUT_FORMAT: ${{ inputs.format }}
         INPUT_DISABLE_MATCHER: ${{ inputs.disable_matcher }}
       run: |
-        problem_matcher_file="${{ github.action_path }}/.github/problem-matcher-${INPUT_FORMAT}.json"
+        problem_matcher_file="${GITHUB_ACTION_PATH}/.github/problem-matcher-${INPUT_FORMAT}.json"
         if [[ "${INPUT_DISABLE_MATCHER}" != "true" && -f "$problem_matcher_file"  ]]; then
           echo "::add-matcher::$problem_matcher_file"
         fi
@@ -80,17 +80,17 @@ runs:
 
         baseurl="https://github.com/koalaman/shellcheck/releases/download"
 
-        curl -Lso "${{ github.action_path }}/sc.tar.xz" \
+        curl -Lso "${GITHUB_ACTION_PATH}/sc.tar.xz" \
           "${baseurl}/${INPUT_VERSION}/shellcheck-${INPUT_VERSION}.${osvariant}.x86_64.tar.xz"
 
-        tar -xf "${{ github.action_path }}/sc.tar.xz" -C "${{ github.action_path }}"
-        mv "${{ github.action_path }}/shellcheck-${INPUT_VERSION}/shellcheck" \
-          "${{ github.action_path }}/shellcheck"
+        tar -xf "${GITHUB_ACTION_PATH}/sc.tar.xz" -C "${GITHUB_ACTION_PATH}"
+        mv "${GITHUB_ACTION_PATH}/shellcheck-${INPUT_VERSION}/shellcheck" \
+          "${GITHUB_ACTION_PATH}/shellcheck"
 
     - name: Display shellcheck version
       shell: bash
       run: |
-        "${{ github.action_path }}/shellcheck" --version
+        "${GITHUB_ACTION_PATH}/shellcheck" --version
 
     - name: Set options
       shell: bash
@@ -214,12 +214,12 @@ runs:
             -print0)
 
         if [[ -n "${INPUT_CHECK_TOGETHER}" ]]; then
-          "${{ github.action_path }}/shellcheck" \
+          "${GITHUB_ACTION_PATH}/shellcheck" \
             ${INPUT_SHELLCHECK_OPTIONS} \
             "${filepaths[@]}" || statuscode=$?
         else
           for file in "${filepaths[@]}"; do
-            "${{ github.action_path }}/shellcheck" \
+            "${GITHUB_ACTION_PATH}/shellcheck" \
               ${INPUT_SHELLCHECK_OPTIONS} \
               "$file" || statuscode=$?
           done

--- a/action.yaml
+++ b/action.yaml
@@ -64,7 +64,8 @@ runs:
       run: |
         problem_matcher_file="${GITHUB_ACTION_PATH}/.github/problem-matcher-${INPUT_FORMAT}.json"
         if [[ "${INPUT_DISABLE_MATCHER}" != "true" && -f "$problem_matcher_file"  ]]; then
-          echo "::add-matcher::$problem_matcher_file"
+          cp ${problem_matcher_file} "$HOME/"
+          echo "::add-matcher::$HOME/problem-matcher-${INPUT_FORMAT}.json"
         fi
 
     - name: Download shellcheck


### PR DESCRIPTION
`${GITHUB_ACTION_PATH}` resolves correctly inside and outside of containers, `${{ github.action_path }}` resolves to a host path inside of containers, which breaks.  See https://github.com/actions/runner/issues/716