### PR TITLE
Add support to run action on self-hosted runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,3 +166,28 @@ If running the latest stable version of Shellcheck is not to your liking, you ca
      with:
        version: v0.9.0
 ```
+
+## Run Spellcheck in self-hosted runner
+
+To run Spellcheck in self-hosted container, first need to add all OS requirements based on container image used.
+(For Rockylinux 8 image, xz and findutils for example)
+
+```yaml
+on: push
+
+name: "Trigger: Push action"
+
+jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: [self-hosted, rocky]
+    container: rockylinux:8
+    steps:
+      - uses: actions/checkout@v3
+      - name: OS packages
+        run: |
+          dnf install xz findutils -y
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
+ ```
+ 

--- a/action.yaml
+++ b/action.yaml
@@ -70,17 +70,17 @@ runs:
 
         baseurl="https://github.com/koalaman/shellcheck/releases/download"
 
-        curl -Lso "${{ github.action_path }}/sc.tar.xz" \
+        curl -Lso "${GITHUB_ACTION_PATH}/sc.tar.xz" \
           "${baseurl}/${INPUT_VERSION}/shellcheck-${INPUT_VERSION}.${osvariant}.x86_64.tar.xz"
 
-        tar -xf "${{ github.action_path }}/sc.tar.xz" -C "${{ github.action_path }}"
-        mv "${{ github.action_path }}/shellcheck-${INPUT_VERSION}/shellcheck" \
-          "${{ github.action_path }}/shellcheck"
+        tar -xf "${GITHUB_ACTION_PATH}/sc.tar.xz" -C "${GITHUB_ACTION_PATH}"
+        mv "${GITHUB_ACTION_PATH}/shellcheck-${INPUT_VERSION}/shellcheck" \
+          "${GITHUB_ACTION_PATH}/shellcheck"
 
     - name: Display shellcheck version
       shell: bash
       run: |
-        "${{ github.action_path }}/shellcheck" --version
+        "${GITHUB_ACTION_PATH}/shellcheck" --version
 
     - name: Set options
       shell: bash
@@ -204,12 +204,12 @@ runs:
             -print0)
 
         if [[ -n "${INPUT_CHECK_TOGETHER}" ]]; then
-          "${{ github.action_path }}/shellcheck" \
+          "${GITHUB_ACTION_PATH}/shellcheck" \
             ${INPUT_SHELLCHECK_OPTIONS} \
             "${filepaths[@]}" || statuscode=$?
         else
           for file in "${filepaths[@]}"; do
-            "${{ github.action_path }}/shellcheck" \
+            "${GITHUB_ACTION_PATH}/shellcheck" \
               ${INPUT_SHELLCHECK_OPTIONS} \
               "$file" || statuscode=$?
           done


### PR DESCRIPTION
 Use GITHUB_ACTION_PATH instead of github.action_path for Docker compliance
Add in README.md instruction to run on self-hosted container (missing packages)