### PR TITLE
Adjust shebang-regex to match s6-overlay with-contenv shebang

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -155,7 +155,7 @@ runs:
       run: |
         statuscode=0
         declare -a filepaths
-        shebangregex="^#! */[^ ]*/(env *)?[abk]*sh"
+        shebangregex="^#! */[^ ]*/(with-cont)?(env *)?[abk]*sh"
 
         set -f # temporarily disable globbing so that globs in inputs aren't expanded
 


### PR DESCRIPTION
This PR enhances the shebang regex to match the common [s6-overlay environment shebang](https://github.com/just-containers/s6-overlay#container-environment) by adding an optional capture group.

```bash
#!/command/with-contenv bash
```
