### PR TITLE
Update actions/checkout version on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ jobs:
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master
 ```


### PR DESCRIPTION
I just updated the README.md example to use `actions/checkout@v4` instead of `actions/checkout@v3` to resolve the following warning in the actions:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

We have tested it on the bashunit actions, and [it works perfectly](https://github.com/TypedDevs/bashunit/actions/runs/8184672682/) with the new version.