### PR TITLE
Improve descriptions of action outputs

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -46,10 +46,10 @@ inputs:
     default: "stable"
 outputs:
   files:
-    description: A list of files with issues
+    description: The list of files checked
     value: ${{ steps.check.outputs.filepaths }}
   options:
-    description: The options used
+    description: Shellcheck options used
     value: ${{ steps.options.outputs.options }}
 branding:
   icon: "terminal"


### PR DESCRIPTION
The "files" output isn't a list of files where shellcheck has detected violations, but the full list of files that shellcheck was invoked on.