### PR TITLE
Add option to skip downloading shellcheck on every run

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Shellcheck can print output in these formats: `checkstyle`, `diff`, `gcc`, `json
 
 ## Run a specific version of Shellcheck
 
-If running the latest stable version of Shellcheck is not to your liking, you can specify a concrete version of Shellcheck to be used. When specifying a custom version, please use any of the released versions listed in the [Shellcheck repository](https://github.com/koalaman/shellcheck/tags).
+If downloading the latest stable version of Shellcheck on each run is not to your liking, you can specify a concrete version of Shellcheck to be used, or skip downloading altogether in favor of pre-installed shellcheck in GitHub-hosted runners. When specifying a concrete version, please use any of the released versions listed in the [Shellcheck repository](https://github.com/koalaman/shellcheck/tags).
 
 ```yaml
    ...
@@ -166,3 +166,5 @@ If running the latest stable version of Shellcheck is not to your liking, you ca
      with:
        version: v0.9.0
 ```
+
+To skip downloading shellcheck, use the special value `version: system`. Note that the version of Shellcheck [present in GitHub Actions runner images](https://github.com/actions/runner-images) might be behind the latest released version of Shellcheck.

--- a/action.yaml
+++ b/action.yaml
@@ -41,7 +41,7 @@ inputs:
     required: false
     default: "gcc"
   version:
-    description: "Specify a concrete version of ShellCheck to use"
+    description: "The version of ShellCheck to download. Set to 'system' to use pre-installed shellcheck."
     required: false
     default: "stable"
 outputs:
@@ -61,26 +61,30 @@ runs:
       shell: bash
       env:
         INPUT_VERSION: ${{ inputs.version }}
+        OS_NAME: ${{ runner.os }}
       run: |
-        if [[ "${{ runner.os }}" == "macOS" ]]; then
-          osvariant="darwin"
-        else
-          osvariant="linux"
+        if [ "${INPUT_VERSION}" = "system" ]; then
+          echo "Using system shellcheck: $(command -v shellcheck)"
+          exit 0
         fi
 
-        baseurl="https://github.com/koalaman/shellcheck/releases/download"
+        if [ "${OS_NAME}" = "macOS" ]; then
+          osvariant="darwin"
+          download_dir="$(mktemp -d -t shellcheck)"
+        else
+          osvariant="linux"
+          download_dir="$(mktemp -d --tmpdir shellcheck.XXX)"
+        fi
 
-        curl -Lso "${{ github.action_path }}/sc.tar.xz" \
-          "${baseurl}/${INPUT_VERSION}/shellcheck-${INPUT_VERSION}.${osvariant}.x86_64.tar.xz"
+        curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/${INPUT_VERSION}/shellcheck-${INPUT_VERSION}.${osvariant}.x86_64.tar.xz" | \
+          tar -xz -C "${download_dir}" --strip-components 1 -- "shellcheck-${INPUT_VERSION}/shellcheck"
 
-        tar -xf "${{ github.action_path }}/sc.tar.xz" -C "${{ github.action_path }}"
-        mv "${{ github.action_path }}/shellcheck-${INPUT_VERSION}/shellcheck" \
-          "${{ github.action_path }}/shellcheck"
+        echo "${download_dir}" >> "$GITHUB_PATH"
 
     - name: Display shellcheck version
       shell: bash
       run: |
-        "${{ github.action_path }}/shellcheck" --version
+        shellcheck --version
 
     - name: Set options
       shell: bash
@@ -204,13 +208,11 @@ runs:
             -print0)
 
         if [[ -n "${INPUT_CHECK_TOGETHER}" ]]; then
-          "${{ github.action_path }}/shellcheck" \
-            ${INPUT_SHELLCHECK_OPTIONS} \
+          shellcheck ${INPUT_SHELLCHECK_OPTIONS} \
             "${filepaths[@]}" || statuscode=$?
         else
           for file in "${filepaths[@]}"; do
-            "${{ github.action_path }}/shellcheck" \
-              ${INPUT_SHELLCHECK_OPTIONS} \
+            shellcheck ${INPUT_SHELLCHECK_OPTIONS} \
               "$file" || statuscode=$?
           done
         fi


### PR DESCRIPTION
When reviewing this action, I was surprised that it downloads shellcheck on every run even though shellcheck comes pre-installed with GitHub Actions runner images.

With special `version: system` action input value, this will skip downloading shellcheck from GitHub on every run and instead use the shellcheck version that comes preinstalled. This is an alternative approach to https://github.com/ludeeus/action-shellcheck/pull/100

Otherwise, when shellcheck is downloaded, it is extracted into a temporary directory (as opposed to `github.action_path`) which is then added to PATH.