### PR TITLE
Add an option to check all executable scripts

### DIFF
--- a/.github/workflows/scandir.yml
+++ b/.github/workflows/scandir.yml
@@ -73,7 +73,7 @@ jobs:
       run: |
         expect="testfiles/scandir/unknown-shebang"
 
-        if [[ ! "${{ steps.two.outputs.files }}" =~ $expect ]];then
-          echo "::error:: Expected file $expect not found in ${{ steps.two.outputs.files }}"
+        if [[ ! "${{ steps.three.outputs.files }}" =~ $expect ]];then
+          echo "::error:: Expected file $expect not found in ${{ steps.three.outputs.files }}"
           exit 1
         fi

--- a/.github/workflows/scandir.yml
+++ b/.github/workflows/scandir.yml
@@ -61,3 +61,19 @@ jobs:
           echo "::error:: Expected file $notexpect found in ${{ steps.two.outputs.files }}"
           exit 1
         fi
+
+    - name: Run ShellCheck
+      uses: ./
+      id: three
+      with:
+        scandir: './testfiles/scandir'
+        all_scripts: true
+
+    - name: Verify check
+      run: |
+        expect="testfiles/scandir/unknown-shebang"
+
+        if [[ ! "${{ steps.two.outputs.files }}" =~ $expect ]];then
+          echo "::error:: Expected file $expect not found in ${{ steps.two.outputs.files }}"
+          exit 1
+        fi

--- a/action.yaml
+++ b/action.yaml
@@ -6,6 +6,10 @@ inputs:
     description: "A space separated list of additional filename to check"
     required: false
     default: ""
+  all_scripts:
+    description: "Set to true to check all executable scripts. The default is to check only ones with known shebangs"
+    required: false
+    default: ""
   ignore:
     description: "Paths to ignore when running ShellCheck"
     required: false
@@ -147,6 +151,7 @@ runs:
       shell: bash
       id: check
       env:
+        INPUT_ALL_SCRIPTS: ${{ inputs.all_scripts }}
         INPUT_SCANDIR: ${{ inputs.scandir }}
         INPUT_CHECK_TOGETHER: ${{ inputs.check_together }}
         INPUT_EXCLUDE_ARGS: ${{ steps.exclude.outputs.excludes }}
@@ -155,7 +160,8 @@ runs:
       run: |
         statuscode=0
         declare -a filepaths
-        shebangregex="^#! */[^ ]*/(env *)?[abk]*sh"
+        shebangregex="^#!"
+        [ "$INPUT_ALL_SCRIPTS" = "true" ] || shebangregex="^#! */[^ ]*/(env *)?[abk]*sh"
 
         set -f # temporarily disable globbing so that globs in inputs aren't expanded
 

--- a/testfiles/scandir/unknown-shebang
+++ b/testfiles/scandir/unknown-shebang
@@ -1,0 +1,3 @@
+#!/usr/bin/with-contenv bashio
+
+echo "hi"


### PR DESCRIPTION
By default, this action only checks extension-less executable scripts _if_ they have a known shebang such as `#!/usr/bin/env bash`. The new option `all_scripts: true` relaxes the shebang regex pattern so that any executable scripts are checked by shellcheck.

This is suitable for repositories with scripts that have unusual shebangs, such as the HomeAssistant addons repository that contains dozens of scripts with shebangs like `#!/usr/bin/with-contenv bashio` that were not included in the shellcheck linting CI check: https://github.com/home-assistant/addons/pull/3803#issuecomment-2423080124

I considered using `additional_files` for that repository, but there were many unique script names, and my idea was to ensure that all scripts are linted by default, even future ones added with unique names that someone might forget to add to `additional_files`.

Please let me know if a new action input approach I took here is acceptable. Thank you!